### PR TITLE
add build requirements

### DIFF
--- a/sailfish/rpm/harbour-jupii.spec
+++ b/sailfish/rpm/harbour-jupii.spec
@@ -27,6 +27,8 @@ BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
+BuildRequires:  pkgconfig(libcurl)
+BuildRequires:  pulseaudio-devel
 BuildRequires:  desktop-file-utils
 
 %description

--- a/sailfish/rpm/harbour-jupii.yaml
+++ b/sailfish/rpm/harbour-jupii.yaml
@@ -25,9 +25,11 @@ PkgConfigBR:
   - Qt5Core
   - Qt5Qml
   - Qt5Quick
+  - libcurl
 
 # Build dependencies without a pkgconfig setup can be listed here
-# PkgBR:
+PkgBR:
+  - pulseaudio-devel
 #   - package-needed-to-build
 
 # Runtime dependencies which are not automatically detected


### PR DESCRIPTION
libcurl and pulseaudio-devel are required to successfully build in the SDK